### PR TITLE
Update CTR Mode and Add Tests

### DIFF
--- a/src/aes-modes.jl
+++ b/src/aes-modes.jl
@@ -154,10 +154,10 @@ function AESCTR(blocks::String, key::String, iv::String)
 end
 
 # Carries out AES in CTR mode on the given blocks using the given key.
-# CBC mode is carried out in encryption direction if the parameter
+# CTR mode is carried out in encryption direction if the parameter
 # encrypt is true. Otherwise, CTR mode is carried out in decryption
-# direction. Treats the low eight bytes of the iv array as the little endian
-# counter.
+# direction. Treats the least-significant eight bytes of the iv array
+# as the big endian counter.
 function AESCTR(blocks::Array{UInt8, 1}, key::Array{UInt8, 1},
 	iv::Array{UInt8, 1})
 	noBlocks = keyStreamCheck(blocks, key, iv)
@@ -167,10 +167,10 @@ function AESCTR(blocks::Array{UInt8, 1}, key::Array{UInt8, 1},
 	for i=1:noBlocks
 		indices = blockIndices(blocks, i)
 		eb = AESEncrypt(curr, key)
-    o[indices] = xor.(eb[1:length(indices)] , blocks[indices])
-		for bi=(length(curr) - 7):length(curr)
+		o[indices] = xor.(eb[1:length(indices)] , blocks[indices])
+		for bi=reverse((length(curr) - 7):length(curr))
 			tmp = curr[bi]
-			curr[bi] = UInt8(Int(tmp) + 1)
+			curr[bi] = UInt8(mod(Int(tmp) + 1, 256))
 			if curr[bi] > tmp
 				# no byte overflow
 				break

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -91,10 +91,14 @@ const cipher7 = cipher6
 @test AESOFB(cipher7, key7, iv7) == plain7
 
 # AES CTR
-const iv8 =     "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff" # is actually the nonce
+# Test with three blocks for AES to test counter incrementation
+# Source: https://github.com/servo/nss/blob/3d07e85a597ce9c5c1ec80f85983efcb26aa58e1/cmd/bltest/tests/aes_ctr/aes_ctr_tests_source.txt#L27-L48
+const iv8 =     "f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff" # is actually the nonce for the first block
+# "f0f1f2f3f4f5f6f7f8f9fafbfcfdff00" is the nonce for the second block
+# "f0f1f2f3f4f5f6f7f8f9fafbfcfdff01" is the nonce for the third block
 const key8 =    key4
-const plain8 =  plain4
-const cipher8 = "874d6191b620e3261bef6864990db6ce"
+const plain8 =  string(plain4, "ae2d8a571e03ac9c9eb76fac45af8e51", "30c81c46a35ce411e5fbc1191a0a52ef")
+const cipher8 = string("874d6191b620e3261bef6864990db6ce", "9806f66b7970fdff8617187bb9fffdff", "5ae4df3edbd5d35e5b4f09020db03eab")
 
 @test AESCTR(plain8, key8, iv8) == cipher8
 @test AESCTR(cipher8, key8, iv8) == plain8


### PR DESCRIPTION
Treat the counter in CTR mode as bytes in big endian order instead of
little endian order.
Add a test for CTR mode that encrypts three blocks.